### PR TITLE
Better default path to libtropic

### DIFF
--- a/NUCLEO_F439ZI/CMakeLists.txt
+++ b/NUCLEO_F439ZI/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../toolchain.cmake)
 # Paths to stm32 drivers
 set(PATH_TO_STM32CUBEF4 "Vendor/STM32CubeF4/Drivers" )
 # Path to libtropic
-set(PATH_TO_LIBTROPIC "../../../../")
+set(PATH_TO_LIBTROPIC "../../libtropic")
 
 
 ###########################################################################

--- a/NUCLEO_L432KC/CMakeLists.txt
+++ b/NUCLEO_L432KC/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../toolchain.cmake)
 # Paths to stm32 drivers
 set(PATH_TO_STM32CUBEL4 "Vendor/STM32CubeL4/Drivers" )
 # Path to libtropic
-set(PATH_TO_LIBTROPIC "../../../../")
+set(PATH_TO_LIBTROPIC "../../libtropic")
 
 
 ###########################################################################


### PR DESCRIPTION
This is more of a proposal to make the project more foolproof.
Users  typically checkout repositories next to each other into the same folder like here:
```
ls -la
drwxrwxr-x 13 kkyovsky kkyovsky 4096 bře 11 23:32 libtropic
drwxrwxr-x  5 kkyovsky kkyovsky 4096 bře 11 23:49 libtropic-stm32

```
The PATH_TO_LIBTROPIC should respect that directory structure. I modified the CMakeLists.txt files to respect that.
I believe this change will make it faster and easier for newcomers to compile the binaries.