### PR TITLE
Add test finish reporting

### DIFF
--- a/NUCLEO_F439ZI/Src/main.c
+++ b/NUCLEO_F439ZI/Src/main.c
@@ -171,6 +171,8 @@ int main(void)
   /*int*/ lt_test_erase_r_config();
 #endif
 
+  LT_FINISH_TEST();
+
   // libtropic related code END
   // libtropic related code END
   // libtropic related code END

--- a/NUCLEO_L432KC/Src/main.c
+++ b/NUCLEO_L432KC/Src/main.c
@@ -214,6 +214,8 @@ int main(void)
   /*int*/ lt_test_erase_r_config();
 #endif
 
+  LT_FINISH_TEST();
+
   // libtropic related code END
   // libtropic related code END
   // libtropic related code END


### PR DESCRIPTION
I added a macro to the end of each platform's test handler to correctly signalize the end of the test to the test runner.