### PR TITLE
Fix f439zi hal name

### DIFF
--- a/NUCLEO_F439ZI/CMakeLists.txt
+++ b/NUCLEO_F439ZI/CMakeLists.txt
@@ -94,7 +94,7 @@ set(SOURCES
     Src/startup_stm32f429zitx.s
     Src/syscalls.c
     Src/sysmem.c
-    ${PATH_TO_LIBTROPIC}/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
+    ${PATH_TO_LIBTROPIC}/hal/port/stm32/libtropic_port_stm32_nucleo_f439zi.c
 )
 
 set(HEADERS

--- a/NUCLEO_F439ZI/Src/main.c
+++ b/NUCLEO_F439ZI/Src/main.c
@@ -25,7 +25,7 @@
 #include "libtropic_examples.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "lt_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32_nucleo_f439zi.h"
 #include "syscalls.h"
 
 /** @addtogroup STM32F4xx_HAL_Examples


### PR DESCRIPTION
Propagates changes from https://github.com/tropicsquare/libtropic/pull/259.